### PR TITLE
Implement WiFi and SNTP time synchronization

### DIFF
--- a/include/time_sync.h
+++ b/include/time_sync.h
@@ -1,0 +1,47 @@
+#ifndef TIME_SYNC_H
+#define TIME_SYNC_H
+#include "esp_wifi.h"
+#include "esp_log.h"
+#include "esp_sntp.h"
+#include "esp_netif_sntp.h"
+#include "esp_err.h"
+#include <stdlib.h>
+#include <time.h>
+
+extern time_t now;
+extern char strftime_buf[64];
+extern struct tm timeinfo;
+
+/**
+ *  @brief Connect to WiFi network
+ *  @param ssid - SSID of the WiFi network
+ *  @param password - Password of the WiFi network
+ *  @return esp_err_t - ESP_OK on success, ESP_FAIL or ESP_ERR_TIMEOUT otherwise
+ */
+esp_err_t connect_wifi(const char* ssid, const char* password);
+
+/**
+ *  @brief Shutdown WiFi connection and cleanup resources
+ */
+void shutdown_wifi(void);
+
+/**
+ *  @brief Initialize SNTP time synchronization (requires active WiFi connection)
+ *  @param timezone - Timezone string (e.g., "BRT3" for Brazil Standard Time)
+ *  @param ntp_server - NTP server address (e.g., "a.st1.ntp.br")
+ *  @return esp_err_t - ESP_OK on success, ESP_ERR_TIMEOUT or other error code otherwise
+ */
+esp_err_t init_sntp_sync(const char* timezone, const char* ntp_server);
+
+/**
+ *  @brief Connect to WiFi and synchronize time with NTP server (all-in-one function)
+ *  @param ssid - SSID of the WiFi network
+ *  @param password - Password of the WiFi network
+ *  @param timezone - Timezone string (e.g., "BRT3" for Brazil Standard Time)
+ *  @param ntp_server - NTP server address (e.g., "a.st1.ntp.br")
+ *  @return esp_err_t - ESP_OK on success, error code otherwise
+ */
+esp_err_t sync_time_with_ntp(const char* ssid, const char* password, 
+                              const char* timezone, const char* ntp_server);
+
+#endif // TIME_SYNC_H

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include "esp_timer.h"
 #include "button_driver.h"
 #include "uart_json_handler.h" 
+#include "time_sync.h"
 
 #define MIC_ADC_PIN 33
 #define MIC_ADC_CHANEL ADC_CHANNEL_5
@@ -72,9 +73,6 @@ void app_main(void)
         ESP_LOGE("main", "Falha ao criar buffer");
         return;
     }
-    
-    // Inicializa sistema de histórico em RAM
-    init_history_system(60); 
 
     // Inicializa botão com interrupção GPIO e callback assíncrono
     button_init(&btn_nav, (gpio_num_t)BUTTON_PIN, button_callback, xMainTaskHandle);
@@ -95,6 +93,13 @@ void app_main(void)
         ESP_LOGW("BUTTON_TEST", "REBOOTING NOW!");
         esp_restart();
     }
+
+    // Inicializa sistema de histórico em RAM
+    init_history_system(60); 
+
+    // Sincroniza hora com NTP via WiFi
+    ret = sync_time_with_ntp("90225", "Segred0%%@2444", NULL, NULL);
+    ESP_ERROR_CHECK(ret);
 
     sensor_base_t bh1750 = {0}, dht11 = {0}, ky_037 = {0};
 
@@ -162,7 +167,9 @@ void av_cal_monitor_timer_callback(TimerHandle_t xTimer) {
                  RAW_TO_NOISE(compact_read.noise_level));
         // Monta registro com timestamp e grava na flash
         flash_record_t frec = {0};
-        frec.timestamp = (uint32_t)(esp_timer_get_time() / 1000000ULL);
+        time_t now;
+        time(&now);
+        frec.timestamp = (uint32_t)now; 
         frec.compact = compact_read;
         flash_buffer_write(buffer, &frec);
     }

--- a/src/time_sync.c
+++ b/src/time_sync.c
@@ -1,0 +1,177 @@
+#include "time_sync.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "esp_event.h"
+#include "esp_netif.h"
+
+time_t now;
+char strftime_buf[64];
+struct tm timeinfo;
+
+static const char* TAG = "time_sync";
+static EventGroupHandle_t wifi_event_group;
+static const int WIFI_CONNECTED_BIT = BIT0;
+static const int WIFI_FAIL_BIT = BIT1;
+static int s_retry_num = 0;
+#define MAX_RETRY_ATTEMPTS 5
+
+static wifi_config_t wifi_config = {
+        .sta = {
+            .ssid = {0},
+            .password = {0},
+            .threshold.authmode = WIFI_AUTH_WPA2_PSK,
+        },
+    };
+
+static void wifi_event_handler(void* arg, esp_event_base_t event_base,
+                               int32_t event_id, void* event_data)
+{
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        esp_wifi_connect();
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        if (s_retry_num < MAX_RETRY_ATTEMPTS) {
+            esp_wifi_connect();
+            s_retry_num++;
+            ESP_LOGI(TAG, "Tentando reconectar ao WiFi (%d/%d)...", s_retry_num, MAX_RETRY_ATTEMPTS);
+        } else {
+            xEventGroupSetBits(wifi_event_group, WIFI_FAIL_BIT);
+            ESP_LOGE(TAG, "Falha ao conectar ao WiFi após %d tentativas", MAX_RETRY_ATTEMPTS);
+        }
+    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
+        ESP_LOGI(TAG, "Endereço IP obtido: " IPSTR, IP2STR(&event->ip_info.ip));
+        s_retry_num = 0;
+        xEventGroupSetBits(wifi_event_group, WIFI_CONNECTED_BIT);
+    }
+}
+
+esp_err_t connect_wifi(const char* ssid, const char* password) {
+    // Initialize network interface
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+    esp_netif_create_default_wifi_sta();
+    
+    // Create event group
+    wifi_event_group = xEventGroupCreate();
+    
+    // Initialize WiFi
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+    
+    // Register event handlers
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT,
+                                                        ESP_EVENT_ANY_ID,
+                                                        &wifi_event_handler,
+                                                        NULL,
+                                                        NULL));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT,
+                                                        IP_EVENT_STA_GOT_IP,
+                                                        &wifi_event_handler,
+                                                        NULL,
+                                                        NULL));
+    
+    // Setup WiFi as Station
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    
+    // Configure WiFi connection settings
+    strncpy((char*)wifi_config.sta.ssid, ssid, sizeof(wifi_config.sta.ssid));
+    strncpy((char*)wifi_config.sta.password, password, sizeof(wifi_config.sta.password));
+    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config));
+    
+    // Start WiFi
+    ESP_ERROR_CHECK(esp_wifi_start());
+
+    // Wait for connection
+    ESP_LOGI(TAG, "Conectando ao WiFi SSID: %s...", ssid);
+    EventBits_t bits = xEventGroupWaitBits(wifi_event_group,
+                                           WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+                                           pdFALSE,
+                                           pdFALSE,
+                                           portMAX_DELAY);
+    
+    if (bits & WIFI_CONNECTED_BIT) {
+        ESP_LOGI(TAG, "Conectado ao WiFi SSID: %s", ssid);
+        return ESP_OK;
+    } else if (bits & WIFI_FAIL_BIT) {
+        ESP_LOGE(TAG, "Falha ao conectar ao WiFi SSID: %s", ssid);
+        return ESP_FAIL;
+    } else {
+        ESP_LOGE(TAG, "Evento inesperado ao conectar WiFi");
+        return ESP_ERR_TIMEOUT;
+    }
+}
+
+void shutdown_wifi() {
+    if (wifi_event_group) {
+        vEventGroupDelete(wifi_event_group);
+        wifi_event_group = NULL;
+    }
+    ESP_ERROR_CHECK(esp_event_handler_instance_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_instance_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, NULL));
+    ESP_ERROR_CHECK(esp_wifi_stop());
+    ESP_ERROR_CHECK(esp_wifi_deinit());
+    ESP_ERROR_CHECK(esp_event_loop_delete_default());
+    esp_netif_deinit();
+    ESP_LOGI(TAG, "WiFi desligado");
+}
+
+esp_err_t init_sntp_sync(const char* timezone, const char* ntp_server)
+{
+    // Set timezone
+    setenv("TZ", timezone ? timezone : "BRT3", 1);
+    tzset();
+    
+    // Initialize SNTP
+    ESP_LOGI(TAG, "Inicializando sincronização SNTP...");
+    esp_sntp_config_t config = ESP_NETIF_SNTP_DEFAULT_CONFIG(ntp_server ? ntp_server : "a.st1.ntp.br");
+    esp_err_t ret = esp_netif_sntp_init(&config);
+    
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Falha ao inicializar SNTP: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    
+    // Wait for time to be synchronized (with timeout)
+    int retry = 0;
+    const int retry_count = 15;
+    while (esp_netif_sntp_sync_wait(pdMS_TO_TICKS(2000)) == ESP_ERR_TIMEOUT && ++retry < retry_count) {
+        ESP_LOGI(TAG, "Aguardando sincronização SNTP... (%d/%d)", retry, retry_count);
+    }
+    
+    if (retry >= retry_count) {
+        ESP_LOGW(TAG, "Timeout na sincronização SNTP");
+        return ESP_ERR_TIMEOUT;
+    }
+    
+    // Get and display current time
+    time(&now);
+    localtime_r(&now, &timeinfo);
+    strftime(strftime_buf, sizeof(strftime_buf), "%c", &timeinfo);
+    ESP_LOGI(TAG, "Hora sincronizada: %s", strftime_buf);
+    
+    return ESP_OK;
+}
+
+esp_err_t sync_time_with_ntp(const char* ssid, const char* password, 
+                              const char* timezone, const char* ntp_server)
+{
+    esp_err_t ret;
+    
+    // Connect to WiFi
+    ret = connect_wifi(ssid, password);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Falha ao conectar WiFi, abortando sincronização SNTP");
+        return ret;
+    }
+    
+    // Initialize and sync SNTP
+    ret = init_sntp_sync(timezone, ntp_server);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Falha na sincronização SNTP");
+        shutdown_wifi();
+        return ret;
+    }
+    
+    ESP_LOGI(TAG, "Sincronização de tempo concluída com sucesso");
+    return ESP_OK;
+}


### PR DESCRIPTION
This PR implements the time synchronization module to properly establish WiFi connection before SNTP sync.

**Changes:**
- Add time_sync module with WiFi connection and SNTP sync functions
- Implement connect_wifi() with event-driven connection handling
- Add init_sntp_sync() for timezone-aware time synchronization
- Add sync_time_with_ntp() as all-in-one convenience function
- Update main.c to sync system time on startup before sensor init
- Replace esp_timer timestamps with real-time UNIX timestamps

closes #43 